### PR TITLE
AsyncLazy simplification

### DIFF
--- a/JustSaying/AwsTools/AsyncLazy.cs
+++ b/JustSaying/AwsTools/AsyncLazy.cs
@@ -3,14 +3,9 @@ using System.Threading.Tasks;
 
 namespace JustSaying.AwsTools
 {
-    // TODO Does this still meet async best-practice?
-
     internal sealed class AsyncLazy<T> : Lazy<Task<T>>
     {
-        public AsyncLazy(Func<T> valueFactory) :
-            base(() => Task.Factory.StartNew(valueFactory)) { }
-
         public AsyncLazy(Func<Task<T>> taskFactory) :
-            base(() => Task.Factory.StartNew(() => taskFactory()).Unwrap()) { }
+            base(taskFactory) { }
     }
 }


### PR DESCRIPTION
Suggested simplification, as you pointed out `StartNew` was a bit of a smell, we can use `Task.Run`, however where we use it, we aren't looking to start threads for the synchronous start of the delegate passed into the delegate, so it all reduces to something quite short.